### PR TITLE
fix incorrect path for __init__.py in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         VERSION_TO_SET="${{ env.version }}"
-        INIT_PY_PATH="model-service/__init__.py" # Path for model-service
+        INIT_PY_PATH="model-service/app/__init__.py" # Path for model-service
 
         git config --global user.name 'GitHub Actions Bot'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
Changed the value of the INIT_PY_PATH variable to point at the correct location so the release workflow can correctly update the version of the artifacts.